### PR TITLE
fix: 文字数カウントにおいて空白文字をカウントから除外する

### DIFF
--- a/src/components/DocumentList.tsx
+++ b/src/components/DocumentList.tsx
@@ -2,6 +2,7 @@ import type React from 'react'
 import { useEffect, useState } from 'react'
 import {
   type Document,
+  countCharacter,
   createDocument,
   deleteDocument,
   generateUUID,
@@ -94,7 +95,7 @@ export const DocumentList: React.FC<DocumentListProps> = ({
     try {
       const json = JSON.parse(content)
       const text = extractTextFromLexicalJSON(json)
-      return text.length
+      return countCharacter(text)
     } catch {
       return 0
     }

--- a/src/components/editorplugins/CurrentInfo.tsx
+++ b/src/components/editorplugins/CurrentInfo.tsx
@@ -1,6 +1,8 @@
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { $getRoot } from 'lexical'
 import { useEffect, useState } from 'react'
+import { countCharacter } from '../../utils/documentManager'
+
 import * as styles from './CurrentInfo.css'
 
 function CurrentInfo() {
@@ -13,7 +15,7 @@ function CurrentInfo() {
       editor.getEditorState().read(() => {
         const root = $getRoot()
         const textContent = root.getTextContent()
-        setCharacterCount(textContent.length)
+        setCharacterCount(countCharacter(textContent))
         setLineCount(textContent.split('\n').length)
       })
     })
@@ -22,7 +24,7 @@ function CurrentInfo() {
       const root = $getRoot()
       const textContent = root.getTextContent()
       const _lineCount = textContent.split('\n').length
-      setCharacterCount(textContent.length)
+      setCharacterCount(countCharacter(textContent))
       setLineCount(_lineCount)
     })
 

--- a/src/utils/documentManager.ts
+++ b/src/utils/documentManager.ts
@@ -84,3 +84,9 @@ export const getDocument = (id: string): Document | null => {
   const documents = getDocuments()
   return documents.find((doc) => doc.id === id) || null
 }
+
+export const countCharacter = (text: string): number => {
+  // 正規表現で空白文字を除去してから文字数カウントを行う
+  const re = /\s/g
+  return text.replace(re, '').length
+}


### PR DESCRIPTION
この手のエディタでは一般に空白文字をカウントしないか、空白文字をカウントしない場合とする場合の両方の文字数表示がなされると思います。
そのため、ひとまず空白文字をカウントから除外するように変更しました。

空白をカウントする場合においても、少なくとも、改行文字が文字数としてカウントされるのは違和感があります。
そのため、現状の実装は空白文字全てをカウントしませんが、これを改行のみカウントしないように書き換えることも可能です。

なお、空白文字のカウントが意図した仕様であれば、申し訳ありませんがcloseをお願いします。